### PR TITLE
acceptance: do not use 127.0.0.1 for host

### DIFF
--- a/playbooks/wazo-acceptance/run.yaml
+++ b/playbooks/wazo-acceptance/run.yaml
@@ -19,7 +19,7 @@
             linphone: True
           instances:
             default:
-              wazo_host: 127.0.0.1
+              wazo_host: "{{ ansible_default_ipv4.address }}"
 
     - name: Setup acceptance tests
       shell: "tox -e setup"


### PR DESCRIPTION
reason: We run test/docker on the same host that wazo-platform. The
wazo_host value is used to indicate on which host linphone must
register. Since linphone run on a docker, if we set 127.0.0.1, the
REGISTER will never go out the container ...
This is why we set wazo_host on a valid ipv4 that redirect on the
host