### PR TITLE
debian-packaging: ignore debian packaging from upstream

### DIFF
--- a/roles/debian-packaging/tasks/main.yaml
+++ b/roles/debian-packaging/tasks/main.yaml
@@ -1,5 +1,5 @@
 - name: Download orig sources if needed or update changelog
-  shell: "if grep -q get-orig-source debian/rules; then debian/rules get-orig-source; tar xvf ../*.tar* --strip 1; else dch -b -v $(../xivo-ci/bin/wazo-package-version $(wget -q -O - http://mirror.wazo.community/version/unstable)) --distribution $distribution --force-distribution \"$(git log -1 HEAD --pretty=format:%s)\"; fi"
+  shell: "if grep -q get-orig-source debian/rules; then debian/rules get-orig-source; tar xvf ../*.tar* --strip 1 --exclude 'debian/*'; else dch -b -v $(../xivo-ci/bin/wazo-package-version $(wget -q -O - http://mirror.wazo.community/version/unstable)) --distribution $distribution --force-distribution \"$(git log -1 HEAD --pretty=format:%s)\"; fi"
   args:
     chdir: "{{ zuul.project.src_dir }}"
 


### PR DESCRIPTION
Why:

* If upstream tarball contains debian packaging instructions, then our
own packaging instructions will be overwritten by upstream.