### PR TITLE
acceptance: use docker host ip to provide phone config

### DIFF
--- a/playbooks/wazo-acceptance/run.yaml
+++ b/playbooks/wazo-acceptance/run.yaml
@@ -23,7 +23,7 @@
             xivo_test_helpers: True
           instances:
             default:
-              wazo_host: "{{ ansible_default_ipv4.address }}"
+              wazo_host: "{{ ansible_docker0.ipv4.address }}"
 
     - name: Setup acceptance tests
       shell: "tox -e setup"


### PR DESCRIPTION
reason: to use linphone to connect through a basic trunk
configuration, asterisk seems to match subnet of IP. Since I don't
understand very well how asterisk register work, then it's simpler to
only change the config instead of trying to find which config should
work.